### PR TITLE
Only enable the sexy bash prompt in iTerm.app

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,5 +1,5 @@
 # Prompt
-if [ -f ~/.bash_prompt ]; then
+if [ -f ~/.bash_prompt -a $TERM_PROGRAM == "iTerm.app" ]; then
   source ~/.bash_prompt
 fi
 


### PR DESCRIPTION
Only enable the sexy bash prompt in iTerm.app, not Terminal.app to prevent the `<blink>` effect.

You may or may not prefer to move the check to the `.bash_prompt` file itself.

Also, this uses `$TERM_PROGRAM` since I don’t know of a way to detect color support. When you feed Terminal.app `tput colors`, it returns `256`. LIES.
