### PR TITLE
Fixed git-rank-contributers for ruby 1.9

### DIFF
--- a/.scripts/git-rank-contributors
+++ b/.scripts/git-rank-contributors
@@ -34,7 +34,7 @@ htmlize = ARGV.delete("-h")
 
 author = nil
 state = :pre_author
-`git log -M -C -C -p --no-color`.each do |l|
+`git log -M -C -C -p --no-color`.each_line do |l|
   case
   when (state == :pre_author || state == :post_author) && l =~ /Author: (.*)$/
     author = $1


### PR DESCRIPTION
String.each has been depricated since ruby 1.9 which cause this script to fail.
