### PR TITLE
Only set $TERM when not a dumb terminal

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -3,7 +3,7 @@
 # A big thanks to \amethyst on Freenode
 
 if [[ $COLORTERM = gnome-* && $TERM = xterm ]]  && infocmp gnome-256color >/dev/null 2>&1; then export TERM=gnome-256color
-elif infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
+elif [[ $TERM != dumb ]] && infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
 fi
 
 if tput setaf 1 &> /dev/null; then


### PR DESCRIPTION
[extra info](https://github.com/danheberden/dotfiles/issues/1) - basically setting `TERM` when a dumb terminal is connecting causes problems for git. I ran into this trying to clone a git repo over SSH, and kept getting "fatal: protocol error: bad line length character:"
