### PR TITLE
Prompt always shows files changed in git 1.8.1.2 on MacOS

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -34,7 +34,7 @@ else
 fi
 
 parse_git_dirty () {
-  [[ $(git status 2> /dev/null | tail -n1) != "nothing to commit (working directory clean)" ]] && echo "*"
+  [[ $(git status 2> /dev/null | tail -n1 | cut -c 1-17) != "nothing to commit" ]] && echo "*"
 }
 parse_git_branch () {
   git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"


### PR DESCRIPTION
Git 1.7.9.5 in Ubuntu 12.04 says "nothing to commit (working directory clean)". But git 1.8.1.2 on MacOS says "nothing to commit, working directory clean", which doesn't work here. It always says that files are changed when they're not. Haven't tried it on Ubuntu 13.04 yet.

This fix will work on both versions of git.
